### PR TITLE
Rejuvenate log levels (N = 24000, CONFIG/WARNING/SEVERE).

### DIFF
--- a/java/client/src/com/thoughtworks/selenium/condition/DefaultConditionRunner.java
+++ b/java/client/src/com/thoughtworks/selenium/condition/DefaultConditionRunner.java
@@ -173,7 +173,7 @@ public class DefaultConditionRunner implements ConditionRunner {
     }
 
     protected void log(String message) {
-      logger.info(new Date() + " - " + message);
+      logger.finest(new Date() + " - " + message);
     }
 
   }

--- a/java/client/src/org/openqa/selenium/interactions/Actions.java
+++ b/java/client/src/org/openqa/selenium/interactions/Actions.java
@@ -380,7 +380,7 @@ public class Actions {
 
     // Of course, this is the offset from the centre of the element. We have no idea what the width
     // and height are once we execute this method.
-    LOG.info("When using the W3C Action commands, offsets are from the center of element");
+    LOG.fine("When using the W3C Action commands, offsets are from the center of element");
     return moveInTicks(target, xOffset, yOffset);
   }
 

--- a/java/client/src/org/openqa/selenium/net/UrlChecker.java
+++ b/java/client/src/org/openqa/selenium/net/UrlChecker.java
@@ -70,7 +70,7 @@ public class UrlChecker {
   public void waitUntilAvailable(long timeout, TimeUnit unit, final URL... urls)
       throws TimeoutException {
     long start = System.nanoTime();
-    log.fine("Waiting for " + Arrays.toString(urls));
+    log.info("Waiting for " + Arrays.toString(urls));
     try {
       timeLimiter.callWithTimeout((Callable<Void>) () -> {
         HttpURLConnection connection = null;
@@ -79,7 +79,7 @@ public class UrlChecker {
         while (true) {
           for (URL url : urls) {
             try {
-              log.fine("Polling " + url);
+              log.info("Polling " + url);
               connection = connectToUrl(url);
               if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 return null;
@@ -110,7 +110,7 @@ public class UrlChecker {
   public void waitUntilUnavailable(long timeout, TimeUnit unit, final URL url)
       throws TimeoutException {
     long start = System.nanoTime();
-    log.fine("Waiting for " + url);
+    log.info("Waiting for " + url);
     try {
       timeLimiter.callWithTimeout((Callable<Void>) () -> {
         HttpURLConnection connection = null;
@@ -118,7 +118,7 @@ public class UrlChecker {
         long sleepMillis = MIN_POLL_INTERVAL_MS;
         while (true) {
           try {
-            log.fine("Polling " + url);
+            log.info("Polling " + url);
             connection = connectToUrl(url);
             if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
               return null;

--- a/java/client/src/org/openqa/selenium/remote/LocalFileDetector.java
+++ b/java/client/src/org/openqa/selenium/remote/LocalFileDetector.java
@@ -50,7 +50,7 @@ public class LocalFileDetector implements FileDetector {
     }
     File toUpload = new File(parentDir, file.getName());
 
-    log.fine("Detected local file: " + toUpload.exists());
+    log.info("Detected local file: " + toUpload.exists());
 
     return toUpload.exists() && toUpload.isFile() ? toUpload : null;
   }

--- a/java/client/src/org/openqa/selenium/remote/ProtocolHandshake.java
+++ b/java/client/src/org/openqa/selenium/remote/ProtocolHandshake.java
@@ -76,7 +76,7 @@ public class ProtocolHandshake {
 
         if (result.isPresent()) {
           Result toReturn = result.get();
-          LOG.info(String.format("Detected dialect: %s", toReturn.dialect));
+          LOG.finer(String.format("Detected dialect: %s", toReturn.dialect));
           return toReturn;
         }
       }

--- a/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
@@ -75,7 +75,7 @@ public class W3CHttpResponseCodec extends AbstractHttpResponseCodec {
   @Override
   public Response decode(HttpResponse encodedResponse) {
     String content = string(encodedResponse).trim();
-    log.fine(String.format(
+    log.finest(String.format(
       "Decoding response. Response code was: %d and content: %s",
       encodedResponse.getStatus(),
       content));

--- a/java/client/test/com/thoughtworks/selenium/BaseSuite.java
+++ b/java/client/test/com/thoughtworks/selenium/BaseSuite.java
@@ -35,13 +35,13 @@ public class BaseSuite {
   public static ExternalResource testEnvironment = new ExternalResource() {
     @Override
     protected void before() {
-      log.info("Preparing test environment");
+      log.fine("Preparing test environment");
       GlobalTestEnvironment.get(SeleniumTestEnvironment.class);
       System.setProperty("webdriver.remote.shorten_log_messages", "true");
     }
     @Override
     protected void after() {
-      log.info("Cleaning test environment");
+      log.finest("Cleaning test environment");
       TestEnvironment environment = GlobalTestEnvironment.get();
       if (environment != null) {
         environment.stop();

--- a/java/client/test/org/openqa/selenium/testing/drivers/ExternalDriverSupplier.java
+++ b/java/client/test/org/openqa/selenium/testing/drivers/ExternalDriverSupplier.java
@@ -102,7 +102,7 @@ class ExternalDriverSupplier implements Supplier<WebDriver> {
     Optional<Class<? extends Supplier<WebDriver>>> supplierClass = getDelegateClass();
     if (supplierClass.isPresent()) {
       Class<? extends Supplier<WebDriver>> clazz = supplierClass.get();
-      logger.info("Using delegate supplier: " + clazz.getName());
+      logger.finest("Using delegate supplier: " + clazz.getName());
       try {
         @SuppressWarnings("unchecked")
         Constructor<Supplier<WebDriver>> ctor =
@@ -122,7 +122,7 @@ class ExternalDriverSupplier implements Supplier<WebDriver> {
     String delegateClassName = System.getProperty(DELEGATE_SUPPLIER_CLASS_PROPERTY);
     if (delegateClassName != null) {
       try {
-        logger.info("Loading custom supplier: " + delegateClassName);
+        logger.finer("Loading custom supplier: " + delegateClassName);
         Class<? extends Supplier<WebDriver>> clazz =
             (Class<? extends Supplier<WebDriver>>) Class.forName(delegateClassName);
         return Optional.of(clazz);

--- a/java/server/src/org/openqa/grid/internal/ActiveTestSessions.java
+++ b/java/server/src/org/openqa/grid/internal/ActiveTestSessions.java
@@ -111,12 +111,12 @@ public class ActiveTestSessions {
       String keyId = externalkey != null ? externalkey.getKey() : "(null externalkey)";
       if (sessionTerminationReason != null) {
           String msg = "Session [" + keyId + "] was terminated due to " + sessionTerminationReason;
-          log.fine(msg);
+          log.finest(msg);
           throw new GridException(msg);
       }
       String msg = "Session [" + keyId + "] not available and is not among the last 1000 terminated sessions.\n"
           + "Active sessions are" + this.unmodifiableSet();
-      log.fine(msg);
+      log.finest(msg);
       throw new GridException(msg);
     }
     return sessionByExternalKey;

--- a/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
+++ b/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
@@ -369,7 +369,7 @@ public class BaseRemoteProxy implements RemoteProxy {
         proxyClass = BaseRemoteProxy.class.getCanonicalName();
       }
       Class<?> clazz = Class.forName(proxyClass);
-      log.fine("Using class " + clazz.getName());
+      log.finest("Using class " + clazz.getName());
       Object[] args = new Object[]{request, registry};
       Class<?>[] argsClass = new Class[]{RegistrationRequest.class, GridRegistry.class};
       Constructor<?> c = clazz.getConstructor(argsClass);

--- a/java/server/src/org/openqa/grid/internal/DefaultGridRegistry.java
+++ b/java/server/src/org/openqa/grid/internal/DefaultGridRegistry.java
@@ -304,7 +304,7 @@ public class DefaultGridRegistry extends BaseGridRegistry implements GridRegistr
     if (proxy == null) {
       return;
     }
-    LOG.info("Registered a node " + proxy);
+    LOG.finer("Registered a node " + proxy);
     try {
       lock.lock();
 

--- a/java/server/src/org/openqa/grid/internal/ProxySet.java
+++ b/java/server/src/org/openqa/grid/internal/ProxySet.java
@@ -125,7 +125,7 @@ public class ProxySet implements Iterable<RemoteProxy> {
     // test running, to avoid putting all the load of the first
     // proxies.
     List<RemoteProxy> sorted = getSorted();
-    log.fine("Available nodes: " + sorted);
+    log.finer("Available nodes: " + sorted);
     return sorted.stream()
         .map(proxy -> proxy.getNewSession(desiredCapabilities))
         .filter(Objects::nonNull)

--- a/java/server/src/org/openqa/grid/internal/utils/SelfRegisteringRemote.java
+++ b/java/server/src/org/openqa/grid/internal/utils/SelfRegisteringRemote.java
@@ -173,7 +173,7 @@ public class SelfRegisteringRemote {
       registrationRequest.getConfiguration().fixUpHost();
     }
     fixUpId();
-    LOG.fine("Using the json request : " + new Json().toJson(registrationRequest));
+    LOG.info("Using the json request : " + new Json().toJson(registrationRequest));
 
     Boolean register = registrationRequest.getConfiguration().register;
     if (register == null) {
@@ -258,11 +258,11 @@ public class SelfRegisteringRemote {
 
       // browserTimeout and timeout are always fetched from the hub. Nodes don't have default values.
       // If a node has browserTimeout or timeout configured, those will have precedence over the hub.
-      LOG.fine(
+      LOG.info(
           "Fetching browserTimeout and timeout values from the hub before sending registration request");
       try {
         GridHubConfiguration hubConfiguration = getHubConfiguration();
-        LOG.fine("Hub configuration: " + new Json().toJson(hubConfiguration));
+        LOG.info("Hub configuration: " + new Json().toJson(hubConfiguration));
         if (hubConfiguration.timeout == null || hubConfiguration.browserTimeout == null) {
           throw new GridException("Hub browserTimeout or timeout (or both) are null");
         }
@@ -284,7 +284,7 @@ public class SelfRegisteringRemote {
           registrationRequest.getConfiguration().browserTimeout = hubConfiguration.browserTimeout;
         }
 
-        LOG.fine("Updated node configuration: " + new Json()
+        LOG.info("Updated node configuration: " + new Json()
             .toJson(registrationRequest.getConfiguration()));
       } catch (Exception e) {
         LOG.warning(
@@ -324,7 +324,7 @@ public class SelfRegisteringRemote {
       Class<? extends Servlet> servletClass = ExtraServletUtil.createServlet(s);
       if (servletClass != null) {
         String path = "/extra/" + servletClass.getSimpleName() + "/*";
-        LOG.info("binding " + servletClass.getCanonicalName() + " to " + path);
+        LOG.finest("binding " + servletClass.getCanonicalName() + " to " + path);
         nodeServlets.put(path, servletClass);
       }
     }

--- a/java/server/src/org/openqa/grid/selenium/GridLauncherV3.java
+++ b/java/server/src/org/openqa/grid/selenium/GridLauncherV3.java
@@ -230,7 +230,7 @@ public class GridLauncherV3 {
     }
 
     configureLogging(common.getLog(), common.getDebug());
-    log.info(version());
+    log.finest(version());
     return true;
   }
 

--- a/java/server/src/org/openqa/grid/web/servlet/RegistrationServlet.java
+++ b/java/server/src/org/openqa/grid/web/servlet/RegistrationServlet.java
@@ -73,7 +73,7 @@ public class RegistrationServlet extends RegistryBasedServlet {
     try (BufferedReader rd = new BufferedReader(new InputStreamReader(request.getInputStream()))) {
       requestJsonString = CharStreams.toString(rd);
     }
-    log.fine("getting the following registration request  : " + requestJsonString);
+    log.info("getting the following registration request  : " + requestJsonString);
 
     // getting the settings from the registration
     Map<String, Object> json = JSON.toType(requestJsonString, MAP_TYPE);
@@ -92,7 +92,7 @@ public class RegistrationServlet extends RegistryBasedServlet {
     // Thread safety reviewed
     new Thread(() -> {
       getRegistry().add(proxy);
-      log.fine("proxy added " + proxy.getRemoteHost());
+      log.info("proxy added " + proxy.getRemoteHost());
     }).start();
   }
 

--- a/java/server/src/org/openqa/grid/web/servlet/handler/RequestHandler.java
+++ b/java/server/src/org/openqa/grid/web/servlet/handler/RequestHandler.java
@@ -105,7 +105,7 @@ public class RequestHandler implements Comparable<RequestHandler> {
   public void process() {
     switch (request.getRequestType()) {
       case START_SESSION:
-        log.info("Got a request to create a new session: "
+        log.fine("Got a request to create a new session: "
                  + new DesiredCapabilities(request.getDesiredCapabilities()));
         try {
           registry.addNewSessionRequest(this);

--- a/java/server/src/org/openqa/selenium/docker/Container.java
+++ b/java/server/src/org/openqa/selenium/docker/Container.java
@@ -35,7 +35,7 @@ public class Container {
   private final ContainerId id;
 
   public Container(Function<HttpRequest, HttpResponse> client, ContainerId id) {
-    LOG.info("Created container " + id);
+    LOG.finest("Created container " + id);
     this.client = Objects.requireNonNull(client);
     this.id = Objects.requireNonNull(id);
   }
@@ -63,7 +63,7 @@ public class Container {
   }
 
   public void delete() {
-    LOG.info("Removing " + getId());
+    LOG.finest("Removing " + getId());
 
     HttpRequest request = new HttpRequest(DELETE, "/containers/" + id);
     client.apply(request);

--- a/java/server/src/org/openqa/selenium/docker/Docker.java
+++ b/java/server/src/org/openqa/selenium/docker/Docker.java
@@ -88,7 +88,7 @@ public class Docker {
 
     findImage(new ImageNamePredicate(name, tag));
 
-    LOG.info(String.format("Pulling %s:%s", name, tag));
+    LOG.finest(String.format("Pulling %s:%s", name, tag));
 
     HttpRequest request = new HttpRequest(POST, "/images/create");
     request.addQueryParameter("fromImage", name);
@@ -96,7 +96,7 @@ public class Docker {
 
     client.apply(request);
 
-    LOG.info(String.format("Pull of %s:%s complete", name, tag));
+    LOG.finest(String.format("Pull of %s:%s complete", name, tag));
 
     return findImage(new ImageNamePredicate(name, tag))
         .orElseThrow(() -> new DockerException(
@@ -104,7 +104,7 @@ public class Docker {
   }
 
   public List<Image> listImages() {
-    LOG.fine("Listing images");
+    LOG.finest("Listing images");
     HttpResponse response = client.apply(new HttpRequest(GET, "/images/json"));
 
     List<ImageSummary> images =
@@ -118,7 +118,7 @@ public class Docker {
   public Optional<Image> findImage(Predicate<Image> filter) {
     Objects.requireNonNull(filter);
 
-    LOG.fine("Finding image: " + filter);
+    LOG.finest("Finding image: " + filter);
 
     return listImages().stream()
         .filter(filter)
@@ -133,7 +133,7 @@ public class Docker {
       output.write(info);
     }
 
-    LOG.info("Creating container: " + json);
+    LOG.finest("Creating container: " + json);
 
     HttpRequest request = new HttpRequest(POST, "/containers/create");
     request.setContent(utf8String(json));

--- a/java/server/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
@@ -43,7 +43,7 @@ class BoundZmqEventBus implements EventBus {
     Addresses xpubAddr = deriveAddresses(address, publishConnection);
     Addresses xsubAddr = deriveAddresses(address, subscribeConnection);
 
-    LOG.info(String.format("XPUB binding to %s, XSUB binding to %s", xpubAddr, xsubAddr));
+    LOG.finest(String.format("XPUB binding to %s, XSUB binding to %s", xpubAddr, xsubAddr));
 
     xpub = context.createSocket(SocketType.XPUB);
     xpub.setImmediate(true);

--- a/java/server/src/org/openqa/selenium/events/zeromq/UnboundEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/UnboundEventBus.java
@@ -61,7 +61,7 @@ class UnboundZmqEventBus implements EventBus {
       return thread;
     });
 
-    LOG.info(String.format("Connecting to %s and %s", publishConnection, subscribeConnection));
+    LOG.finest(String.format("Connecting to %s and %s", publishConnection, subscribeConnection));
 
     sub = context.createSocket(SocketType.SUB);
     sub.connect(publishConnection);
@@ -73,7 +73,7 @@ class UnboundZmqEventBus implements EventBus {
     ZMQ.Poller poller = context.createPoller(1);
     poller.register(sub, ZMQ.Poller.POLLIN);
 
-    LOG.info("Sockets created");
+    LOG.finest("Sockets created");
 
     AtomicBoolean pollingStarted = new AtomicBoolean(false);
 

--- a/java/server/src/org/openqa/selenium/grid/commands/Standalone.java
+++ b/java/server/src/org/openqa/selenium/grid/commands/Standalone.java
@@ -119,10 +119,10 @@ public class Standalone implements CliCommand {
       LoggingOptions loggingOptions = new LoggingOptions(config);
       loggingOptions.configureLogging();
 
-      LOG.info("Logging configured.");
+      LOG.finest("Logging configured.");
 
       DistributedTracer tracer = loggingOptions.getTracer();
-      LOG.info("Using tracer: " + tracer);
+      LOG.finest("Using tracer: " + tracer);
       GlobalDistributedTracer.setInstance(tracer);
 
       EventBusConfig events = new EventBusConfig(config);

--- a/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -198,7 +198,7 @@ public class LocalDistributor extends Distributor {
       Host host = new Host(bus, node);
       host.update(status);
       hosts.add(host);
-      LOG.info(String.format("Added node %s.", node.getId()));
+      LOG.finest(String.format("Added node %s.", node.getId()));
       host.runHealthCheck();
 
       Runnable runnable = host::runHealthCheck;

--- a/java/server/src/org/openqa/selenium/grid/docker/DockerOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/docker/DockerOptions.java
@@ -124,7 +124,7 @@ public class DockerOptions {
       for (int i = 0; i < maxContainerCount; i++) {
         node.add(caps, new DockerSessionFactory(clientFactory, docker, image, caps));
       }
-      LOG.info(String.format(
+      LOG.finest(String.format(
           "Mapping %s to docker image %s %d times",
           caps,
           name,

--- a/java/server/src/org/openqa/selenium/grid/docker/DockerSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/grid/docker/DockerSessionFactory.java
@@ -92,7 +92,7 @@ public class DockerSessionFactory implements SessionFactory {
     URL remoteAddress = getUrl(port);
     HttpClient client = clientFactory.createClient(remoteAddress);
 
-    LOG.info("Creating container, mapping container port 4444 to " + port);
+    LOG.finest("Creating container, mapping container port 4444 to " + port);
     Container container = docker.create(image(image).map(Port.tcp(4444), Port.tcp(port)));
     container.start();
 
@@ -130,7 +130,7 @@ public class DockerSessionFactory implements SessionFactory {
                          result.getDialect() :
                          W3C;
 
-    LOG.info(String.format(
+    LOG.finest(String.format(
         "Created session: %s - %s (container id: %s)",
         id,
         capabilities,
@@ -153,7 +153,7 @@ public class DockerSessionFactory implements SessionFactory {
     wait.until(obj -> {
       try {
         HttpResponse response = client.execute(new HttpRequest(GET, "/status"));
-        LOG.fine(string(response));
+        LOG.finest(string(response));
         return 200 == response.getStatus();
       } catch (IOException e) {
         throw new UncheckedIOException(e);

--- a/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -68,7 +68,7 @@ public class NodeOptions {
       Capabilities caps = info.getCanonicalCapabilities();
       builders.stream()
           .filter(builder -> builder.score(caps) > 0)
-          .peek(builder -> LOG.info(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
+          .peek(builder -> LOG.finest(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
           .forEach(builder -> {
             DriverService.Builder freePortBuilder = builder.usingAnyFreePort();
 

--- a/java/server/src/org/openqa/selenium/grid/server/EventBusConfig.java
+++ b/java/server/src/org/openqa/selenium/grid/server/EventBusConfig.java
@@ -51,7 +51,7 @@ public class EventBusConfig {
 
   private EventBus createBus() {
     String clazzName = config.get("events", "implementation").orElse(DEFAULT_CLASS);
-    LOG.info("Creating event bus: " + clazzName);
+    LOG.finest("Creating event bus: " + clazzName);
     try {
       Class<?> busClazz = Class.forName(clazzName);
       Method create = busClazz.getMethod("create", Config.class);

--- a/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
@@ -114,7 +114,7 @@ public class ActiveSessionFactory implements SessionFactory {
     Objects.requireNonNull(onThis, "Predicated needed.");
     Objects.requireNonNull(useThis, "SessionFactory is required");
 
-    LOG.info(String.format("Binding %s to respond to %s", useThis, onThis));
+    LOG.finest(String.format("Binding %s to respond to %s", useThis, onThis));
 
     ImmutableList.Builder<SessionFactory> builder = ImmutableList.builder();
     builder.add(useThis);
@@ -172,10 +172,10 @@ public class ActiveSessionFactory implements SessionFactory {
 
   @Override
   public Optional<ActiveSession> apply(CreateSessionRequest sessionRequest) {
-    LOG.info("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
+    LOG.finest("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
     return factories.stream()
         .filter(factory -> factory.test(sessionRequest.getCapabilities()))
-        .peek(factory -> LOG.info(String.format("Matched factory %s", factory)))
+        .peek(factory -> LOG.finest(String.format("Matched factory %s", factory)))
         .map(factory -> factory.apply(sessionRequest))
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/java/server/src/org/openqa/selenium/remote/server/DefaultDriverProvider.java
+++ b/java/server/src/org/openqa/selenium/remote/server/DefaultDriverProvider.java
@@ -79,7 +79,7 @@ public class DefaultDriverProvider implements DriverProvider {
 
   @Override
   public WebDriver newInstance(Capabilities capabilities) {
-    LOG.info("Creating a new session for " + capabilities);
+    LOG.finest("Creating a new session for " + capabilities);
     // Try and call the single arg constructor that takes a capabilities first
     return callConstructor(driverClass, capabilities);
   }

--- a/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
+++ b/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
@@ -187,7 +187,7 @@ public class JsonHttpCommandHandler {
 
   public void handleRequest(HttpRequest request, HttpResponse resp) {
     LoggingManager.perSessionLogHandler().clearThreadTempLogs();
-    log.fine(String.format("Handling: %s %s", request.getMethod(), request.getUri()));
+    log.finer(String.format("Handling: %s %s", request.getMethod(), request.getUri()));
 
     Command command = null;
     Response response;

--- a/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
@@ -85,7 +85,7 @@ public class SeleniumServer extends BaseServer implements GridNodeServer {
           getClass().getClassLoader())
           .asSubclass(Servlet.class);
       addServlet(rcServlet, "/selenium-server/driver/");
-      LOG.info("Bound legacy RC support");
+      LOG.finest("Bound legacy RC support");
     } catch (ClassNotFoundException e) {
       // Do nothing.
     }

--- a/java/server/src/org/openqa/selenium/remote/server/WebDriverServlet.java
+++ b/java/server/src/org/openqa/selenium/remote/server/WebDriverServlet.java
@@ -190,7 +190,7 @@ public class WebDriverServlet extends HttpServlet {
   private void handle(HttpServletRequest req, HttpServletResponse resp) {
     CommandHandler handler = handlers.match(req);
 
-    LOG.fine("Found handler: " + handler);
+    LOG.finest("Found handler: " + handler);
 
     boolean invalidateSession =
         handler instanceof ActiveSession &&
@@ -222,7 +222,7 @@ public class WebDriverServlet extends HttpServlet {
 
           Thread.currentThread().setName(pathInfo);
         }
-        LOG.fine(String.format(
+        LOG.finest(String.format(
             "%s: Executing %s on %s (handler: %s)",
             Thread.currentThread().getName(),
             req.getMethod(),

--- a/java/server/src/org/openqa/selenium/server/htmlrunner/CoreTestCase.java
+++ b/java/server/src/org/openqa/selenium/server/htmlrunner/CoreTestCase.java
@@ -67,7 +67,7 @@ public class CoreTestCase {
     List<StepResult> stepResults = new ArrayList<>(steps.size());
     NextStepDecorator decorator = NextStepDecorator.IDENTITY;
     for (LoggableStep step : steps) {
-      LOG.info(step.toString());
+      LOG.finest(step.toString());
       decorator = Preconditions.checkNotNull(decorator.evaluate(step, selenium, state), step);
       stepResults.add(new StepResult(step, decorator.getCause()));
       if (!decorator.isOkayToContinueTest()) {

--- a/java/server/src/org/openqa/selenium/server/htmlrunner/NonReflectiveSteps.java
+++ b/java/server/src/org/openqa/selenium/server/htmlrunner/NonReflectiveSteps.java
@@ -106,7 +106,7 @@ class NonReflectiveSteps {
         NextStepDecorator.VERIFICATION_FAILED(value + " not selected"))));
 
     steps.put("echo", ((locator, value) -> (selenium, state) -> {
-      LOG.info(locator);
+      LOG.finest(locator);
       return NextStepDecorator.IDENTITY;
     }));
 


### PR DESCRIPTION
Introduction
---
We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

Feedback Request
---
We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on each of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG/WARNING/SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
2. Never lower the logging level of logging statements within catch blocks.
3. Never lower the logging level of logging statements within if statements.
4. Never lower the logging level of logging statements containing certain (important) keywords.
5. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
6. The greatest number of commits from HEAD evaluated: 24000.

The head at time of analysis was: [8389311](https://github.com/SeleniumHQ/selenium/commit/8389311401473048c215f0885dc5dc5488a311eb)