### PR TITLE
Rejuvenate log levels (N = 1000, CONFIG, NOT RAISE).

### DIFF
--- a/java/client/src/org/openqa/selenium/json/JsonOutput.java
+++ b/java/client/src/org/openqa/selenium/json/JsonOutput.java
@@ -136,7 +136,7 @@ public class JsonOutput implements Closeable {
             GSON_ELEMENT,
             (obj, depth) -> {
               LOG.log(
-                  Level.WARNING,
+                  Level.SEVERE,
                   "Attempt to convert JsonElement from GSON. This functionality is deprecated. "
                   + "Diagnostic stacktrace follows",
                   new JsonException("Stack trace to determine cause of warning"));

--- a/java/client/src/org/openqa/selenium/remote/LocalFileDetector.java
+++ b/java/client/src/org/openqa/selenium/remote/LocalFileDetector.java
@@ -50,7 +50,7 @@ public class LocalFileDetector implements FileDetector {
     }
     File toUpload = new File(parentDir, file.getName());
 
-    log.fine("Detected local file: " + toUpload.exists());
+    log.finest("Detected local file: " + toUpload.exists());
 
     return toUpload.exists() && toUpload.isFile() ? toUpload : null;
   }

--- a/java/client/src/org/openqa/selenium/remote/ProtocolHandshake.java
+++ b/java/client/src/org/openqa/selenium/remote/ProtocolHandshake.java
@@ -76,7 +76,7 @@ public class ProtocolHandshake {
 
         if (result.isPresent()) {
           Result toReturn = result.get();
-          LOG.info(String.format("Detected dialect: %s", toReturn.dialect));
+          LOG.finest(String.format("Detected dialect: %s", toReturn.dialect));
           return toReturn;
         }
       }

--- a/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/codec/w3c/W3CHttpResponseCodec.java
@@ -75,7 +75,7 @@ public class W3CHttpResponseCodec extends AbstractHttpResponseCodec {
   @Override
   public Response decode(HttpResponse encodedResponse) {
     String content = string(encodedResponse).trim();
-    log.fine(String.format(
+    log.finest(String.format(
       "Decoding response. Response code was: %d and content: %s",
       encodedResponse.getStatus(),
       content));

--- a/java/client/test/com/thoughtworks/selenium/InternalSelenseTestBase.java
+++ b/java/client/test/com/thoughtworks/selenium/InternalSelenseTestBase.java
@@ -96,7 +96,7 @@ public class InternalSelenseTestBase extends SeleneseTestBase {
       return;
     }
 
-    log.info("In dev mode. Copying required files in case we're using a WebDriver-backed Selenium");
+    log.finest("In dev mode. Copying required files in case we're using a WebDriver-backed Selenium");
 
     Path dir =
       InProject.locate("java/client/build/production/com/thoughtworks/selenium/webdriven");

--- a/java/client/test/org/openqa/selenium/testing/drivers/TestChromeDriver.java
+++ b/java/client/test/org/openqa/selenium/testing/drivers/TestChromeDriver.java
@@ -66,7 +66,7 @@ public class TestChromeDriver extends RemoteWebDriver implements WebStorage, Loc
             .withVerbose(true)
             .withLogFile(logFile.toFile())
             .build();
-        LOG.info("chromedriver will log to " + logFile);
+        LOG.finest("chromedriver will log to " + logFile);
         service.start();
         // Fugly.
         Runtime.getRuntime().addShutdownHook(new Thread(() -> service.stop()));

--- a/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
+++ b/java/server/src/org/openqa/grid/internal/BaseRemoteProxy.java
@@ -292,7 +292,7 @@ public class BaseRemoteProxy implements RemoteProxy {
 
   @Override
   public TestSession getNewSession(Map<String, Object> requestedCapability) {
-    log.fine("Trying to create a new session on node " + this);
+    log.finest("Trying to create a new session on node " + this);
 
     if (!hasCapability(requestedCapability)) {
       log.fine("Node " + this + " has no matching capability");

--- a/java/server/src/org/openqa/grid/internal/DefaultGridRegistry.java
+++ b/java/server/src/org/openqa/grid/internal/DefaultGridRegistry.java
@@ -304,7 +304,7 @@ public class DefaultGridRegistry extends BaseGridRegistry implements GridRegistr
     if (proxy == null) {
       return;
     }
-    LOG.info("Registered a node " + proxy);
+    LOG.finest("Registered a node " + proxy);
     try {
       lock.lock();
 

--- a/java/server/src/org/openqa/grid/internal/utils/SelfRegisteringRemote.java
+++ b/java/server/src/org/openqa/grid/internal/utils/SelfRegisteringRemote.java
@@ -181,7 +181,7 @@ public class SelfRegisteringRemote {
     }
 
     if (!register) {
-      LOG.info("No registration sent ( register = false )");
+      LOG.fine("No registration sent ( register = false )");
     } else {
       final int
           registerCycleInterval =
@@ -287,7 +287,7 @@ public class SelfRegisteringRemote {
         LOG.fine("Updated node configuration: " + new Json()
             .toJson(registrationRequest.getConfiguration()));
       } catch (Exception e) {
-        LOG.warning(
+        LOG.severe(
             "Error getting the parameters from the hub. The node may end up with wrong timeouts." +
             e.getMessage());
       }
@@ -307,7 +307,7 @@ public class SelfRegisteringRemote {
           throw new GridException(String.format("The hub responded with %s", response.getStatus()));
         }
 
-        LOG.info("The node is registered to the hub and ready to use");
+        LOG.severe("The node is registered to the hub and ready to use");
       } catch (Exception e) {
         throw new GridException("Error sending the registration request: " + e.getMessage());
       }

--- a/java/server/src/org/openqa/grid/selenium/GridLauncherV3.java
+++ b/java/server/src/org/openqa/grid/selenium/GridLauncherV3.java
@@ -230,7 +230,7 @@ public class GridLauncherV3 {
     }
 
     configureLogging(common.getLog(), common.getDebug());
-    log.info(version());
+    log.finest(version());
     return true;
   }
 
@@ -243,7 +243,7 @@ public class GridLauncherV3 {
           }
 
           StandaloneConfiguration configuration = new StandaloneConfiguration(options);
-          log.info(String.format(
+          log.severe(String.format(
               "Launching a standalone Selenium Server on port %s", configuration.port));
           SeleniumServer server = new SeleniumServer(configuration);
           server.boot();
@@ -259,7 +259,7 @@ public class GridLauncherV3 {
           GridHubConfiguration configuration = new GridHubConfiguration(options);
           configuration.setRawArgs(args); // for grid console
 
-          log.info(String.format(
+          log.severe(String.format(
               "Launching Selenium Grid hub on port %s", configuration.port));
           Hub hub = new Hub(configuration);
           hub.start();
@@ -276,13 +276,13 @@ public class GridLauncherV3 {
           if (configuration.port == null || configuration.port == -1) {
             configuration.port = PortProber.findFreePort();
           }
-          log.info(String.format(
+          log.severe(String.format(
               "Launching a Selenium Grid node on port %s", configuration.port));
           SelfRegisteringRemote remote = new SelfRegisteringRemote(configuration);
           SeleniumServer server = new SeleniumServer(remote.getConfiguration());
           remote.setRemoteServer(server);
           if (remote.startRemoteServer()) {
-            log.info("Selenium Grid node is up and ready to register to the hub");
+            log.severe("Selenium Grid node is up and ready to register to the hub");
             remote.startRegistrationProcess();
           }
           return server;

--- a/java/server/src/org/openqa/grid/web/servlet/RegistrationServlet.java
+++ b/java/server/src/org/openqa/grid/web/servlet/RegistrationServlet.java
@@ -73,7 +73,7 @@ public class RegistrationServlet extends RegistryBasedServlet {
     try (BufferedReader rd = new BufferedReader(new InputStreamReader(request.getInputStream()))) {
       requestJsonString = CharStreams.toString(rd);
     }
-    log.fine("getting the following registration request  : " + requestJsonString);
+    log.finest("getting the following registration request  : " + requestJsonString);
 
     // getting the settings from the registration
     Map<String, Object> json = JSON.toType(requestJsonString, MAP_TYPE);
@@ -92,7 +92,7 @@ public class RegistrationServlet extends RegistryBasedServlet {
     // Thread safety reviewed
     new Thread(() -> {
       getRegistry().add(proxy);
-      log.fine("proxy added " + proxy.getRemoteHost());
+      log.finest("proxy added " + proxy.getRemoteHost());
     }).start();
   }
 

--- a/java/server/src/org/openqa/selenium/docker/Container.java
+++ b/java/server/src/org/openqa/selenium/docker/Container.java
@@ -35,7 +35,7 @@ public class Container {
   private final ContainerId id;
 
   public Container(Function<HttpRequest, HttpResponse> client, ContainerId id) {
-    LOG.info("Created container " + id);
+    LOG.finest("Created container " + id);
     this.client = Objects.requireNonNull(client);
     this.id = Objects.requireNonNull(id);
   }
@@ -63,7 +63,7 @@ public class Container {
   }
 
   public void delete() {
-    LOG.info("Removing " + getId());
+    LOG.finest("Removing " + getId());
 
     HttpRequest request = new HttpRequest(DELETE, "/containers/" + id);
     client.apply(request);

--- a/java/server/src/org/openqa/selenium/docker/Docker.java
+++ b/java/server/src/org/openqa/selenium/docker/Docker.java
@@ -88,7 +88,7 @@ public class Docker {
 
     findImage(new ImageNamePredicate(name, tag));
 
-    LOG.info(String.format("Pulling %s:%s", name, tag));
+    LOG.finest(String.format("Pulling %s:%s", name, tag));
 
     HttpRequest request = new HttpRequest(POST, "/images/create");
     request.addQueryParameter("fromImage", name);
@@ -96,7 +96,7 @@ public class Docker {
 
     client.apply(request);
 
-    LOG.info(String.format("Pull of %s:%s complete", name, tag));
+    LOG.finest(String.format("Pull of %s:%s complete", name, tag));
 
     return findImage(new ImageNamePredicate(name, tag))
         .orElseThrow(() -> new DockerException(
@@ -118,7 +118,7 @@ public class Docker {
   public Optional<Image> findImage(Predicate<Image> filter) {
     Objects.requireNonNull(filter);
 
-    LOG.fine("Finding image: " + filter);
+    LOG.finest("Finding image: " + filter);
 
     return listImages().stream()
         .filter(filter)
@@ -133,7 +133,7 @@ public class Docker {
       output.write(info);
     }
 
-    LOG.info("Creating container: " + json);
+    LOG.fine("Creating container: " + json);
 
     HttpRequest request = new HttpRequest(POST, "/containers/create");
     request.setContent(utf8String(json));

--- a/java/server/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/BoundZmqEventBus.java
@@ -43,7 +43,7 @@ class BoundZmqEventBus implements EventBus {
     Addresses xpubAddr = deriveAddresses(address, publishConnection);
     Addresses xsubAddr = deriveAddresses(address, subscribeConnection);
 
-    LOG.info(String.format("XPUB binding to %s, XSUB binding to %s", xpubAddr, xsubAddr));
+    LOG.fine(String.format("XPUB binding to %s, XSUB binding to %s", xpubAddr, xsubAddr));
 
     xpub = context.createSocket(SocketType.XPUB);
     xpub.setImmediate(true);

--- a/java/server/src/org/openqa/selenium/events/zeromq/UnboundEventBus.java
+++ b/java/server/src/org/openqa/selenium/events/zeromq/UnboundEventBus.java
@@ -61,7 +61,7 @@ class UnboundZmqEventBus implements EventBus {
       return thread;
     });
 
-    LOG.info(String.format("Connecting to %s and %s", publishConnection, subscribeConnection));
+    LOG.fine(String.format("Connecting to %s and %s", publishConnection, subscribeConnection));
 
     sub = context.createSocket(SocketType.SUB);
     sub.connect(publishConnection);
@@ -73,7 +73,7 @@ class UnboundZmqEventBus implements EventBus {
     ZMQ.Poller poller = context.createPoller(1);
     poller.register(sub, ZMQ.Poller.POLLIN);
 
-    LOG.info("Sockets created");
+    LOG.fine("Sockets created");
 
     AtomicBoolean pollingStarted = new AtomicBoolean(false);
 

--- a/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
+++ b/java/server/src/org/openqa/selenium/grid/distributor/local/LocalDistributor.java
@@ -198,7 +198,7 @@ public class LocalDistributor extends Distributor {
       Host host = new Host(bus, node);
       host.update(status);
       hosts.add(host);
-      LOG.info(String.format("Added node %s.", node.getId()));
+      LOG.finest(String.format("Added node %s.", node.getId()));
       host.runHealthCheck();
 
       Runnable runnable = host::runHealthCheck;

--- a/java/server/src/org/openqa/selenium/grid/docker/DockerOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/docker/DockerOptions.java
@@ -124,7 +124,7 @@ public class DockerOptions {
       for (int i = 0; i < maxContainerCount; i++) {
         node.add(caps, new DockerSessionFactory(clientFactory, docker, image, caps));
       }
-      LOG.info(String.format(
+      LOG.finer(String.format(
           "Mapping %s to docker image %s %d times",
           caps,
           name,

--- a/java/server/src/org/openqa/selenium/grid/docker/DockerSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/grid/docker/DockerSessionFactory.java
@@ -92,7 +92,7 @@ public class DockerSessionFactory implements SessionFactory {
     URL remoteAddress = getUrl(port);
     HttpClient client = clientFactory.createClient(remoteAddress);
 
-    LOG.info("Creating container, mapping container port 4444 to " + port);
+    LOG.finer("Creating container, mapping container port 4444 to " + port);
     Container container = docker.create(image(image).map(Port.tcp(4444), Port.tcp(port)));
     container.start();
 
@@ -130,7 +130,7 @@ public class DockerSessionFactory implements SessionFactory {
                          result.getDialect() :
                          W3C;
 
-    LOG.info(String.format(
+    LOG.finer(String.format(
         "Created session: %s - %s (container id: %s)",
         id,
         capabilities,
@@ -153,7 +153,7 @@ public class DockerSessionFactory implements SessionFactory {
     wait.until(obj -> {
       try {
         HttpResponse response = client.execute(new HttpRequest(GET, "/status"));
-        LOG.fine(string(response));
+        LOG.finer(string(response));
         return 200 == response.getStatus();
       } catch (IOException e) {
         throw new UncheckedIOException(e);

--- a/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -68,7 +68,7 @@ public class NodeOptions {
       Capabilities caps = info.getCanonicalCapabilities();
       builders.stream()
           .filter(builder -> builder.score(caps) > 0)
-          .peek(builder -> LOG.info(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
+          .peek(builder -> LOG.finest(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
           .forEach(builder -> {
             DriverService.Builder freePortBuilder = builder.usingAnyFreePort();
 

--- a/java/server/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
+++ b/java/server/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
@@ -143,7 +143,7 @@ public class NodeServer implements CliCommand {
           () -> {
             HealthCheck.Result check = node.getHealthCheck().check();
             if (!check.isAlive()) {
-              LOG.info("Node is not alive: " + check.getMessage());
+              LOG.severe("Node is not alive: " + check.getMessage());
               // Throw an exception to force another check sooner.
               throw new UnsupportedOperationException("Node cannot be registered");
             }

--- a/java/server/src/org/openqa/selenium/grid/server/EventBusConfig.java
+++ b/java/server/src/org/openqa/selenium/grid/server/EventBusConfig.java
@@ -51,7 +51,7 @@ public class EventBusConfig {
 
   private EventBus createBus() {
     String clazzName = config.get("events", "implementation").orElse(DEFAULT_CLASS);
-    LOG.info("Creating event bus: " + clazzName);
+    LOG.finest("Creating event bus: " + clazzName);
     try {
       Class<?> busClazz = Class.forName(clazzName);
       Method create = busClazz.getMethod("create", Config.class);

--- a/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
@@ -172,10 +172,10 @@ public class ActiveSessionFactory implements SessionFactory {
 
   @Override
   public Optional<ActiveSession> apply(CreateSessionRequest sessionRequest) {
-    LOG.info("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
+    LOG.finest("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
     return factories.stream()
         .filter(factory -> factory.test(sessionRequest.getCapabilities()))
-        .peek(factory -> LOG.info(String.format("Matched factory %s", factory)))
+        .peek(factory -> LOG.finest(String.format("Matched factory %s", factory)))
         .map(factory -> factory.apply(sessionRequest))
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
+++ b/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
@@ -187,7 +187,7 @@ public class JsonHttpCommandHandler {
 
   public void handleRequest(HttpRequest request, HttpResponse resp) {
     LoggingManager.perSessionLogHandler().clearThreadTempLogs();
-    log.fine(String.format("Handling: %s %s", request.getMethod(), request.getUri()));
+    log.finest(String.format("Handling: %s %s", request.getMethod(), request.getUri()));
 
     Command command = null;
     Response response;

--- a/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
@@ -85,7 +85,7 @@ public class SeleniumServer extends BaseServer implements GridNodeServer {
           getClass().getClassLoader())
           .asSubclass(Servlet.class);
       addServlet(rcServlet, "/selenium-server/driver/");
-      LOG.info("Bound legacy RC support");
+      LOG.finest("Bound legacy RC support");
     } catch (ClassNotFoundException e) {
       // Do nothing.
     }

--- a/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
+++ b/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
@@ -138,18 +138,18 @@ public class ResultConfig {
       return Responses.failure(sessionId, e);
 
     } catch (Exception e) {
-      log.log(Level.WARNING, "Exception thrown", e);
+      log.log(Level.SEVERE, "Exception thrown", e);
 
       Throwable toUse = getRootExceptionCause(e);
 
-      log.warning("Exception: " + toUse.getMessage());
+      log.severe("Exception: " + toUse.getMessage());
       Optional<String> screenshot = Optional.empty();
       if (handler instanceof WebDriverHandler) {
         screenshot = Optional.ofNullable(((WebDriverHandler<?>) handler).getScreenshot());
       }
       response = Responses.failure(sessionId, toUse, screenshot);
     } catch (Error e) {
-      log.info("Error: " + e.getMessage());
+      log.severe("Error: " + e.getMessage());
       response = Responses.failure(sessionId, e);
     }
 


### PR DESCRIPTION
Introduction
---
We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

Feedback Request
---
We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on each of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG/SEVERE/WARNING levels as a category and not a traditional level, i.e., our tool ignores these log levels.
2. Never lower the logging level of logging statements within catch blocks.
3. Never lower the logging level of logging statements within if statements.
4. Never lower the logging level of logging statements containing certain (important) keywords.
5. Never raise the logging level of logging statements with particular keywords in their messages.
6. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
7. The greatest number of commits from HEAD evaluated: 1000.

The head at time of analysis was: [8389311](https://github.com/SeleniumHQ/selenium/commit/8389311401473048c215f0885dc5dc5488a311eb)